### PR TITLE
feat(api): setup Eden Treaty for end-to-end type safety

### DIFF
--- a/apps/backend/index.ts
+++ b/apps/backend/index.ts
@@ -33,3 +33,5 @@ const app = new Elysia()
   .listen(8080); // Strict requirement: Port 8080
 
 console.log(`🦊 Elysia is running at ${app.server?.hostname}:${app.server?.port}`);
+
+export type App = typeof app

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -1,0 +1,4 @@
+import { treaty } from '@elysiajs/eden';
+import type { App } from '@area/backend';
+
+export const client = treaty<App>('http://localhost:8080');

--- a/apps/web/src/routes/+page.svelte
+++ b/apps/web/src/routes/+page.svelte
@@ -1,2 +1,18 @@
+<script>
+	import { client } from '$lib/api';
+
+	// Just testing Eden Treaty
+	async function fetchTest() {
+		const { data, error } = await client.get();
+		if (error) {
+			console.error(error);
+		}
+		console.log(data);
+		return data;
+	}
+
+	fetchTest();
+</script>
+
 <h1>Welcome to SvelteKit</h1>
 <p>Visit <a href="https://svelte.dev/docs/kit">svelte.dev/docs/kit</a> to read the documentation</p>


### PR DESCRIPTION
## 🔍 Context
We are building a Monorepo with **Elysia** (Backend) and **SvelteKit/Expo** (Frontend).
Traditionally, connecting the frontend to the backend involves manually typing `fetch` requests (e.g., `fetch('/about.json')`) and manually defining interfaces for the data we get back. This is error-prone; if the backend changes a property name, the frontend breaks silently.

This PR introduces **Eden Treaty**, an end-to-end type safety solution provided by ElysiaJS.

## ✨ What is Eden Treaty?
Eden Treaty allows us to consume our backend API on the frontend as if it were a standard TypeScript object. It compiles the backend types and exposes them to the clients via a shared reference in the Monorepo.

**Why is this cool?**
1.  **Autocomplete:** You type `client.` and VS Code shows you every available route.
2.  **Refactoring Safety:** If you rename a route or a parameter in the Backend, the Frontend code will immediately show a red error line. You can't ship broken code.
3.  **It's still REST:** Under the hood, it's just standard HTTP requests, satisfying the project requirements.

## 🛠 Implementation Details

### 1. Backend (`apps/backend`)
I have exported the main `App` type from the server instance. This does not expose runtime code, only TypeScript definitions.

```typescript
// apps/backend/index.ts
const app = new Elysia()...
export type App = typeof app; // <--- The magic export
```

### 2. Web Client (`apps/web`)
Connected the client directly to `localhost:8080`.

```typescript
// usage example
const { data, error } = await client.get();
console.log(data); // server response for route / with method GET !
```

## 🚀 How to use

**Before (The "Old" Way):**
```typescript
const response = await fetch('http://localhost:8080/services');
const data = await response.json();
// data is 'any'. We have to guess properties.
// typo 'servces' causes runtime crash.
```

**After (The "Eden" Way):**
```typescript
import { api } from '$lib/api';

const { data, error } = await api.services.get();

if (error) {
    console.error(error.value); // Typed error
}

// 'data' is fully typed.
// If backend changes 'services' to 'providers', this line turns red instantly.
console.log(data);
```

## ⚠️ Notes for the Team
*   **File Uploads:** For complex `multipart/form-data` (like profile pictures), Eden can sometimes be tricky. In those specific rare cases, using a standard `fetch` is an acceptable fallback.

## ✅ Checklist
- [x] Dependencies installed (`@elysiajs/eden`)
- [x] Backend types exported
- [x] Web client configured
- [ ] Mobile client configured with dynamic URL support