### PR TITLE
feat(profile): implement service connection loading and API key handling

### DIFF
--- a/apps/web/src/lib/components/PasswordInput.svelte
+++ b/apps/web/src/lib/components/PasswordInput.svelte
@@ -1,14 +1,14 @@
 <script>
-	import { Eye, EyeClosed } from 'lucide-svelte';
+	import { Eye, EyeClosed, Proportions } from 'lucide-svelte';
 	import Button from './ui/button/button.svelte';
 	import Input from './ui/input/input.svelte';
 
 	let visible = $state(false);
-	let { value = $bindable() } = $props();
+	let { value = $bindable(), ...others } = $props();
 </script>
 
 <div class="relative">
-	<Input type={visible ? 'text' : 'password'} bind:value class="pr-9" />
+	<Input type={visible ? 'text' : 'password'} bind:value class="pr-9" id={others?.id} placeholder={others?.placeholder} />
 	<Button
 		variant="ghost"
 		size="icon"

--- a/apps/web/src/lib/components/ServiceCard.svelte
+++ b/apps/web/src/lib/components/ServiceCard.svelte
@@ -2,9 +2,16 @@
   import type { OAuth2AuthUrlResponseType, ServiceDTO, UserConnectionSchemaType } from "@area/types";
   import ServiceIcon from "./ServiceIcon.svelte";
   import * as Card from "$lib/components/ui/card/index.js";
+  import * as Dialog from "$lib/components/ui/dialog/index.js";
   import { Switch } from "./ui/switch";
   import { getServiceAuthUrl } from "@/api/getServiceAuthUrl";
   import { onMount } from "svelte";
+  import { invalidate } from "$app/navigation";
+  import Label from "./ui/label/label.svelte";
+  import Input from "./ui/input/input.svelte";
+  import PasswordInput from "./PasswordInput.svelte";
+  import { client } from "@/api";
+  import Button from "./ui/button/button.svelte";
 
   interface Props {
     service: ServiceDTO;
@@ -13,61 +20,145 @@
 
   let { service, connections }: Props = $props();
 
-  const isLinked: boolean = $derived(
-    connections.find((con) => {
-      return con.serviceName == service.name;
-    }) != null
-  );
+  const connection = $derived(connections.find(c => c.serviceName === service.name));
+  const isLinked = $derived(!!connection);
 
   let authPromise = $state<Promise<OAuth2AuthUrlResponseType>>();
+  let values = $state<Record<string, string>>({});
+  let isApiKeyDialogOpen = $state(false);
+  let isConfirmDeletionOpen = $state(false);
 
   onMount(() => {
-    authPromise = getServiceAuthUrl(service.name, window.location.href);
+    if (service.authType == "oauth2") authPromise = getServiceAuthUrl(service.name, window.location.href);
   });
+
+  function checkValidity() {
+    if (
+      Object.keys(values).length == service.authFields?.length &&
+      Object.values(values).every((v) => {
+        return v != "" && v != undefined;
+      })
+    ) {
+      return true;
+    }
+    return false;
+  }
+
+  async function onSubmit() {
+    return await client.api.connections.post({
+      serviceName: service.name,
+      accessToken: values["accessToken"],
+      metadata: values
+    });
+  }
+
+  async function deleteConnection() {
+    if (!connection) return;
+
+    try {
+        await client.api.connections({ id: connection.id }).delete();
+        await invalidate('app:connections');
+        isConfirmDeletionOpen = false;
+    } catch (error) {
+        console.error("Failed to delete connection:", error);
+    }
+}
 </script>
 
-{#await authPromise}
-  <Card.Root class="w-xs h-full">
+{#snippet cardContent()}
+  <Card.Root class="w-xs h-full {isLinked ? 'bg-muted text-muted-foreground' : 'cursor-pointer group-hover:border-primary transition-colors'}">
     <Card.Header>
       <div class="flex w-full justify-between items-center">
         <div class="flex gap-5 items-center">
           <ServiceIcon name={service.name} />
           <Card.Title class="capitalize">{service.name}</Card.Title>
         </div>
-        <Switch
-          checked={false}
-          onclick={(e: MouseEvent) => {
-            e.stopPropagation();
-            e.preventDefault();
-          }}
-        />
+        <Dialog.Root bind:open={isConfirmDeletionOpen}>
+          <Dialog.Trigger>
+            <Switch
+              checked={isLinked}
+              onclick={(e: MouseEvent) => {
+                e.stopPropagation();
+                e.preventDefault();
+                if (isLinked) {
+                  isConfirmDeletionOpen = true;
+                }
+              }}
+            />
+          </Dialog.Trigger>
+          <Dialog.Content>
+            <Dialog.Header>
+              <Dialog.Title>Are you sure?</Dialog.Title>
+              <Dialog.Description>
+                This action will delete the connection to this service and cannot be undone.
+              </Dialog.Description>
+            </Dialog.Header>
+            <Dialog.Footer class="flex sm:justify-center sm:items-center">
+              <Button variant="destructive" onclick={deleteConnection}>Confirm Deletion</Button>
+            </Dialog.Footer>
+          </Dialog.Content>
+        </Dialog.Root>
       </div>
       <Card.Description>{service.description}</Card.Description>
     </Card.Header>
   </Card.Root>
-{:then auth}
-  <a
-    aria-label="{service.name} connection"
-    href={auth?.authUrl}
-    class={`group transition-all ${isLinked ? "pointer-events-none cursor-auto" : ""}`}
-  >
-    <Card.Root class={`w-xs h-full ${isLinked ? "bg-muted text-muted-foreground" : ""}`}>
-      <Card.Header>
-        <div class="flex w-full justify-between items-center">
-          <div class="flex gap-5 items-center">
-            <ServiceIcon name={service.name} />
-            <Card.Title class="capitalize">{service.name}</Card.Title>
-          </div>
-          <Switch
-            checked={isLinked}
-            onclick={(e: MouseEvent) => {
-              e.stopPropagation();
-              e.preventDefault();
-            }}
-          />
+{/snippet}
+
+{#if isLinked}
+  {@render cardContent()}
+{:else if service.authType == "oauth2"}
+  {#await authPromise}
+    {@render cardContent()}
+  {:then auth}
+    <a aria-label="{service.name} connection" href={auth?.authUrl} class="group transition-all">
+      {@render cardContent()}
+    </a>
+  {/await}
+{:else}
+  <Dialog.Root bind:open={isApiKeyDialogOpen}>
+    <Dialog.Trigger>
+      <button
+        class="group"
+        onclick={() => {
+          isApiKeyDialogOpen = true;
+        }}
+      >
+        {@render cardContent()}
+      </button>
+    </Dialog.Trigger>
+    <Dialog.Content>
+      <Dialog.Header class="mb-2">
+        <Dialog.Title>Linking {service.name}</Dialog.Title>
+      </Dialog.Header>
+
+      {#each service.authFields as field, i}
+        <div class="flex justify-between items-center">
+          <Label class="text-md" for={i.toString()}>{field.label}</Label>
+          {#if field.required}
+            <p class="text-red-400">Required</p>
+          {/if}
         </div>
-        <Card.Description>{service.description}</Card.Description>
-      </Card.Header>
-    </Card.Root>
-  </a>
-{/await}
+        {#if field.type == "password"}
+          <PasswordInput id={i.toString()} placeholder={field.description} bind:value={values[field.key]} />
+        {:else}
+          <Input id={i.toString()} placeholder={field.description} bind:value={values[field.key]} />
+        {/if}
+      {/each}
+
+      <Dialog.Footer class="flex sm:justify-center sm:items-center">
+        <Button
+          variant="secondary"
+          disabled={!checkValidity()}
+          onclick={() => {
+            onSubmit().then(() => {
+              invalidate('app:connections');
+              isApiKeyDialogOpen = false;
+            });
+          }}
+        >
+          Connect
+        </Button>
+      </Dialog.Footer>
+    </Dialog.Content>
+  </Dialog.Root>
+{/if}

--- a/apps/web/src/routes/profile/+page.ts
+++ b/apps/web/src/routes/profile/+page.ts
@@ -1,0 +1,19 @@
+import { getServices } from '@/api/getServices';
+import { getServiceConnections } from '@/api/getServiceConnections';
+import type { PageLoad } from './$types';
+
+export const ssr = false;
+
+export const load: PageLoad = async ({ depends }) => {
+    depends('app:connections');
+
+    const [services, connections] = await Promise.all([
+        getServices(),
+        getServiceConnections()
+    ]);
+
+    return {
+        services,
+        connections
+    };
+};


### PR DESCRIPTION
This pull request introduces significant improvements to the service connection management flow in the profile page of the web app. The main changes include refactoring data loading to use SvelteKit's load function, adding API key/manual credential support for services, and improving the UI/UX for linking and unlinking services. Additionally, the `PasswordInput` component is made more flexible.

**Profile Page Data Loading and Refactor:**

- Switched to using SvelteKit's `load` function in `+page.ts` to fetch services and connections, replacing client-side `onMount` data fetching. This enables better SSR/CSR support and cleaner code. (`apps/web/src/routes/profile/+page.ts`, [apps/web/src/routes/profile/+page.tsR1-R19](diffhunk://#diff-ec527dab9437d3315f915eb25b39da8f37825c88b3dbca8493fee0b26fd2da5cR1-R19))
- Updated the profile page (`+page.svelte`) to use data from the load function, simplifying the component and removing unnecessary async/await blocks. (`apps/web/src/routes/profile/+page.svelte`, [[1]](diffhunk://#diff-b04c0a1ec68ba49c8f59df44149084268c951a2746ce2750951b54d9130e392fL5-R14) [[2]](diffhunk://#diff-b04c0a1ec68ba49c8f59df44149084268c951a2746ce2750951b54d9130e392fL35-L56)

**Service Connection Management Enhancements:**

- Refactored `ServiceCard.svelte` to support both OAuth2 and manual/API key-based authentication, including a dialog for entering credentials when required by a service. (`apps/web/src/lib/components/ServiceCard.svelte`, [[1]](diffhunk://#diff-b190962feb6954bc62b7c252180cac4e2ad86885ed812adf3df5a1703816cf53R5-R14) [[2]](diffhunk://#diff-b190962feb6954bc62b7c252180cac4e2ad86885ed812adf3df5a1703816cf53L16-R164)
- Added dialogs for confirming deletion of a service connection and for entering API keys or credentials, improving UX and error handling. (`apps/web/src/lib/components/ServiceCard.svelte`, [apps/web/src/lib/components/ServiceCard.svelteL16-R164](diffhunk://#diff-b190962feb6954bc62b7c252180cac4e2ad86885ed812adf3df5a1703816cf53L16-R164))

**Component Improvements:**

- Enhanced `PasswordInput.svelte` to accept additional props such as `id` and `placeholder`, increasing its reusability in forms. (`apps/web/src/lib/components/PasswordInput.svelte`, [apps/web/src/lib/components/PasswordInput.svelteL2-R11](diffhunk://#diff-9e597820cfaff0db42d490d78dde41d65011d3306bcba14b27d8d5a784373151L2-R11))